### PR TITLE
Fix: function returns invalid Base64 String

### DIFF
--- a/src/Strings/StringToBase64.ahk
+++ b/src/Strings/StringToBase64.ahk
@@ -10,11 +10,11 @@ StringToBase64(String, Encoding := "UTF-8")
 
 	Binary := Buffer(StrPut(String, Encoding))
 	StrPut(String, Binary, Encoding)
-	if !(DllCall("crypt32\CryptBinaryToStringW", "Ptr", Binary, "UInt", Binary.Size, "UInt", (CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF), "Ptr", 0, "UInt*", &Size := 0))
+	if !(DllCall("crypt32\CryptBinaryToStringW", "Ptr", Binary, "UInt", Binary.Size - 1, "UInt", (CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF), "Ptr", 0, "UInt*", &Size := 0))
 		throw Error("CryptBinaryToStringW failed", -1)
 
 	Base64 := Buffer(Size << 1, 0)
-	if !(DllCall("crypt32\CryptBinaryToStringW", "Ptr", Binary, "UInt", Binary.Size, "UInt", (CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF), "Ptr", Base64, "UInt*", Size))
+	if !(DllCall("crypt32\CryptBinaryToStringW", "Ptr", Binary, "UInt", Binary.Size - 1, "UInt", (CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF), "Ptr", Base64, "UInt*", Size))
 		throw Error("CryptBinaryToStringW failed", -1)
 
 	return StrGet(Base64)


### PR DESCRIPTION
test string: `onetwth`

Your function currently returns `b25ldHd0aAA=` as the Encoded string for the test string above but that is incorrect. The correct string should be `b25ldHd0aA==` (note the padding mismatch). 

This was caused by sending the incorrect size to the `CryptBinaryToString` function.